### PR TITLE
Manually implement the kabsch algorithm for python2

### DIFF
--- a/cclib/parser/utils.py
+++ b/cclib/parser/utils.py
@@ -202,7 +202,14 @@ def get_rotation(a, b):
             r = scipy.spatial.transform.Rotation.from_dcm(rmat)
         else:
             # we need to remove b_[0] and a_[1] ( both of them are [0,0,0] ) to avoid SVD unconvergence error
-            r, _ = scipy.spatial.transform.Rotation.match_vectors(b_[1:], a_[1:])
+            # Kabsch Algorithm
+            cov = numpy.dot(b_.T, a_)
+            V, S, W = numpy.linalg.svd(cov)
+            if ((numpy.linalg.det(V) * numpy.linalg.det(W))< 0.0):
+                S[-1] = -S[-1]
+                V[:,-1] = -V[:,-1]
+            rmat = numpy.dot(V, W)
+            r = scipy.spatial.transform.Rotation.from_dcm(rmat)
     return r
 
 class PeriodicTable(object):


### PR DESCRIPTION
The example in cclib/cclib#944 works if the kabsch algorithm is reimplemented in python2 since this is what the python3 version is doing. I'm not sure why the `scipy.spatial.transform.Rotation.match_vectors` isn't working. Does this sound like the right way to go about this?

Things I found useful:
http://en.wikipedia.org/wiki/Kabsch_algorithm
https://github.com/charnley/rmsd